### PR TITLE
Fix component naming typos

### DIFF
--- a/src/app/components/essay/season03/memories-from-high-school/page.jsx
+++ b/src/app/components/essay/season03/memories-from-high-school/page.jsx
@@ -3,7 +3,7 @@ import { User } from '@/app/components/essay/User';
 import { AI } from '@/app/components/essay/AI';
 import EssayNavigation from '../../EssayNavigation';
 
-export default function MemoriesFromHighScoolYears({ title, summary }) {
+export default function MemoriesFromHighSchoolYears({ title, summary }) {
   return (
     <div className="essay-content flex flex-col items-center px-4 py-12 max-w-2xl mx-auto">
       <h1 className="text-3xl font-bold mb-8 text-center">{title}</h1>

--- a/src/app/components/essay/season04/fp1100-beta-certainty/page.jsx
+++ b/src/app/components/essay/season04/fp1100-beta-certainty/page.jsx
@@ -3,7 +3,7 @@ import EssayNavigation from '@/app/components/essay/EssayNavigation';
 import { User } from '../../User';
 import { AI } from '../../AI';
 
-export default function FP1100BataCertainty({ title, summary }) {
+export default function FP1100BetaCertainty({ title, summary }) {
   return (
     <div className="essay-content flex flex-col items-center px-4 py-12 max-w-2xl mx-auto">
       <h1 className="text-3xl font-bold mb-8 text-center">{title}</h1>

--- a/src/app/essays/essayComponents.jsx
+++ b/src/app/essays/essayComponents.jsx
@@ -1,17 +1,17 @@
-import MemoriesFromHighScoolYears from '../components/essay/season03/memories-from-high-school/page';
+import MemoriesFromHighSchoolYears from '../components/essay/season03/memories-from-high-school/page';
 import CritiqueAiQuestionBook from '../components/essay/season03/critique-ai-question-book/page';
 import TheUnacknowledgedInitiation from '../components/essay/season03/the-unacknowledged-initiation/page';
 import TheRarestKindOfFriendship from '../components/essay/season03/the-rarest-kind-of-friendship/page';
 import TheOriginOfWWA2 from '../components/essay/season03/origin-of-wwa2/page';
-import FP1100BataCertainty from '../components/essay/season04/fp1100-beta-certainty/page';
+import FP1100BetaCertainty from '../components/essay/season04/fp1100-beta-certainty/page';
 import TheVoidSurface from '../components/essay/season04/the-void-surface/page';
 
 export const essayComponents = {
-  'memories-from-high-school': MemoriesFromHighScoolYears,
+  'memories-from-high-school': MemoriesFromHighSchoolYears,
   'critique-ai-question-book': CritiqueAiQuestionBook,
   'the-unacknowledged-initiation': TheUnacknowledgedInitiation,
   'the-rarest-kind-of-friendship': TheRarestKindOfFriendship,
   'origin-of-wwa2': TheOriginOfWWA2,
-  'fp1100-beta-certainty': FP1100BataCertainty,
+  'fp1100-beta-certainty': FP1100BetaCertainty,
   'the-void-surface': TheVoidSurface
 };


### PR DESCRIPTION
## Summary
- rename `Bata`/`Scool` to `Beta`/`School`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68416500db108333aaea4d3b82434a88