### PR TITLE
Fix next.config.js pageExtensions comma

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,7 +5,7 @@ import remarkGfm from 'remark-gfm';
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Configure `pageExtensions` to include markdown and MDX files
-  pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx']
+  pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
   // Optionally, add any other Next.js config below
 };
 


### PR DESCRIPTION
## Summary
- add trailing comma after pageExtensions array
- attempt to run `next build` to verify config

## Testing
- `npx next build` *(fails: 403 Forbidden when fetching next)*

------
https://chatgpt.com/codex/tasks/task_e_684169faebbc8333866f9eb98c5632fd