### PR TITLE
Centralize type definitions

### DIFF
--- a/src/app/essays/[slug]/page.tsx
+++ b/src/app/essays/[slug]/page.tsx
@@ -1,8 +1,8 @@
 import { notFound } from 'next/navigation';
 import { essayComponents } from '../essayComponents';
 import { essays } from '@/data/essays';
-import type { Essay } from '@types/essay';
-import type { SlugProps, SlugParams } from '@types/routes';
+import type { Essay } from '@/types/essay';
+import type { SlugProps } from '@/types/routes';
 
 export default async function EssayPage({ params }: SlugProps) {
   const { slug } = params; // ここで一回ちゃんと受け取る！
@@ -17,6 +17,8 @@ export default async function EssayPage({ params }: SlugProps) {
   return <EssayComponent title={essayData.title} summary={essayData.summary} />;
 }
 
-export async function generateStaticParams(): Promise<SlugParams[]> {
-  return essays.map(({ slug }) => ({ slug }));
+export async function generateStaticParams(): Promise<
+  { params: { slug: string } }[]
+> {
+  return essays.map(({ slug }) => ({ params: { slug } }));
 }

--- a/src/app/essays/[slug]/page.tsx
+++ b/src/app/essays/[slug]/page.tsx
@@ -4,7 +4,11 @@ import { essays } from '@/data/essays';
 import type { Essay } from '@/types/essay';
 import type { SlugProps } from '@/types/routes';
 
-export default async function EssayPage({ params }: SlugProps) {
+export default async function EssayPage({
+  params
+}: {
+  params: { slug: string };
+}) {
   const { slug } = params; // ここで一回ちゃんと受け取る！
 
   const EssayComponent = await essayComponents[slug];

--- a/src/app/essays/[slug]/page.tsx
+++ b/src/app/essays/[slug]/page.tsx
@@ -1,13 +1,10 @@
 import { notFound } from 'next/navigation';
 import { essayComponents } from '../essayComponents';
 import { essays } from '@/data/essays';
-import type { Essay } from '@/types';
+import type { Essay } from '@types/essay';
+import type { SlugProps, SlugParams } from '@types/routes';
 
-export default async function EssayPage({
-  params
-}: {
-  params: { slug: string };
-}) {
+export default async function EssayPage({ params }: SlugProps) {
   const { slug } = params; // ここで一回ちゃんと受け取る！
 
   const EssayComponent = await essayComponents[slug];
@@ -20,6 +17,6 @@ export default async function EssayPage({
   return <EssayComponent title={essayData.title} summary={essayData.summary} />;
 }
 
-export async function generateStaticParams(): Promise<{ slug: string }[]> {
+export async function generateStaticParams(): Promise<SlugParams[]> {
   return essays.map(({ slug }) => ({ slug }));
 }

--- a/src/app/essays/page.tsx
+++ b/src/app/essays/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { essays } from '@/data/essays';
 import { seasons } from '@/data/seasons';
 import PersistentDetails from '../components/PersistentDetails';
-import type { Essay } from '@/types';
+import type { Essay } from '@types/essay';
 
 export default function EssaysPage() {
   const groupedEssays = essays.reduce<Record<number, Essay[]>>((acc, essay) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@types/*": ["./types/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -15,10 +19,26 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": ["./src/*"],
-      "@types/*": ["./types/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ],
+      "@/types/*": [
+        "./types/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/types/essay.ts
+++ b/types/essay.ts
@@ -4,4 +4,5 @@ export interface Essay {
   summary: string;
   season: number;
   sortOrder: number;
+  // Content or other metadata can be added later
 }

--- a/types/routes.ts
+++ b/types/routes.ts
@@ -1,7 +1,6 @@
-export interface SlugParams {
-  slug: string;
-}
-
-export interface SlugProps {
-  params: SlugParams;
-}
+// types/routes.ts
+export type SlugProps = {
+  params: {
+    slug: string;
+  };
+};

--- a/types/routes.ts
+++ b/types/routes.ts
@@ -1,0 +1,7 @@
+export interface SlugParams {
+  slug: string;
+}
+
+export interface SlugProps {
+  params: SlugParams;
+}


### PR DESCRIPTION
## Summary
- create `types/` directory with shared interfaces
- move `Essay` interface to `types/essay.ts`
- add routing types in `types/routes.ts`
- update pages to import the new types
- map `@types/*` path alias in `tsconfig.json`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684387c5d4848333b45dc064f0b35e19